### PR TITLE
token exceeds limit error fix

### DIFF
--- a/src/modules/chatbot.py
+++ b/src/modules/chatbot.py
@@ -39,7 +39,7 @@ class Chatbot:
 
 
         chain = ConversationalRetrievalChain.from_llm(llm=llm,
-            retriever=retriever, verbose=True, return_source_documents=True, combine_docs_chain_kwargs={'prompt': self.QA_PROMPT})
+            retriever=retriever, verbose=True, return_source_documents=True, max_tokens_limit=4097, combine_docs_chain_kwargs={'prompt': self.QA_PROMPT})
 
         chain_input = {"question": query, "chat_history": st.session_state["history"]}
         result = chain(chain_input)


### PR DESCRIPTION
this can prevent token exceeds limit error fix from OpenAI occurs.  it's for gpt-3.5, if you choose gpt-4, maybe want to save the value in st.session_state, change it to 8192 or 32768 for gpt4-8k and gpt4-32k